### PR TITLE
- null checking when converting to binary tree

### DIFF
--- a/pylib/testing/framework/cpp/cpp_input_converter.py
+++ b/pylib/testing/framework/cpp/cpp_input_converter.py
@@ -187,6 +187,9 @@ class CppInputConverter(TypeConverter):
         child: ConverterFn = self.render(node.first_child(), context)
         src = render_template('''
             vector<shared_ptr<BinaryTreeNode<{{child.ret_type}}>>> nodes;
+            if (value.is_null()) {
+                return nullptr;
+            }
             for (int i = 0; i < value.size(); i++) {
             \tshared_ptr<BinaryTreeNode<{{child.ret_type}}>> node = make_shared<BinaryTreeNode<{{child.ret_type}}>>();
             \tnode->left = nullptr;

--- a/pylib/testing/framework/js/js_input_converter.py
+++ b/pylib/testing/framework/js/js_input_converter.py
@@ -184,6 +184,9 @@ class JsInputConverter(TypeConverter):
         """
         child: ConverterFn = self.render(node.first_child(), context)
         src = render_template('''
+            if (!value) {
+            \treturn null;
+            }
             const nodes = []
             for (let n of value) {
             \tlet node = new BinaryTreeNode()

--- a/pylib/testing/framework/python/python_input_converter.py
+++ b/pylib/testing/framework/python/python_input_converter.py
@@ -168,6 +168,8 @@ class PythonInputConverter(TypeConverter):
         """
         child: ConverterFn = self.render(node.first_child(), context)
         src = render_template('''
+            \tif value is None:
+            \t\treturn None
             \tnodes = []
             \tfor item in value:
             \t\tnode = BinaryTreeNode()

--- a/pylib/testing/framework/tests/test_cpp_input_converter.py
+++ b/pylib/testing/framework/tests/test_cpp_input_converter.py
@@ -142,6 +142,9 @@ class CppInputConverterTests(unittest.TestCase):
         self.assertEqual(ConverterFn('', '''return value.as_string();''', 'jute::jValue', 'string'), converters[0])
         self.assertEqual(ConverterFn('', '''
             vector<shared_ptr<BinaryTreeNode<string>>> nodes;
+            if (value.is_null()) {
+            return nullptr;
+            }
             for (int i = 0; i < value.size(); i++) {
                 shared_ptr<BinaryTreeNode<string>> node = make_shared<BinaryTreeNode<string>>();
                 node->left = nullptr;

--- a/pylib/testing/framework/tests/test_cpp_test_suite_gen.py
+++ b/pylib/testing/framework/tests/test_cpp_test_suite_gen.py
@@ -32,6 +32,7 @@ class CppTestSuiteGeneratorTests(GeneratorTestCase):
             #include <queue>
             #include <set>
             #include <math.h>
+            #include <memory>
             #include <iostream>
             #include <string>
             #include <termios.h>

--- a/pylib/testing/framework/tests/test_java_input_converter.py
+++ b/pylib/testing/framework/tests/test_java_input_converter.py
@@ -138,6 +138,9 @@ class JavaInputConverterTests(unittest.TestCase):
                 }
                 nodes.add(node);
             }
+            if (nodes.isEmpty()) {
+                return null;
+            }
             Deque<BinaryTreeNode<String>> children = new LinkedList<>(nodes);
             BinaryTreeNode<String> root = children.removeFirst();
             for (BinaryTreeNode<String> node : nodes) {
@@ -152,3 +155,49 @@ class JavaInputConverterTests(unittest.TestCase):
             }
             return root;
         ''', 'JsonNode', 'BinaryTreeNode<String>'), converters[1])
+
+
+    def test_array_nested_linked_list(self):
+        tree = SyntaxTree.of(['array(linked_list(string))'])
+        arg_converters, converters = self.converter.get_converters(tree)
+        self.assertEqual(1, len(arg_converters))
+        self.assertEqual(3, len(converters))
+        self.assertEqual(ConverterFn('', '''return value.asText();''', 'JsonNode', 'String'), converters[0])
+        self.assertEqual(ConverterFn('', '''
+            ListNode<String> result[] = new ListNode[value.size()];
+            int i = 0;
+            for (JsonNode node : value) {
+                result[i++] = converter2(node);
+            }
+            return result; 
+        ''', 'JsonNode', 'ListNode<String>[]'), converters[2])
+
+    def test_array_double_nested_linked_list(self):
+        tree = SyntaxTree.of(['array(linked_list(linked_list(string))'])
+        arg_converters, converters = self.converter.get_converters(tree)
+        self.assertEqual(1, len(arg_converters))
+        self.assertEqual(4, len(converters))
+        self.assertEqual(ConverterFn('', '''return value.asText();''', 'JsonNode', 'String'), converters[0])
+        self.assertEqual(ConverterFn('', '''
+            ListNode<ListNode<String>> result[] = new ListNode[value.size()];
+            int i = 0;
+            for (JsonNode node : value) {
+                result[i++] = converter3(node);
+            }
+            return result; 
+        ''', 'JsonNode', 'ListNode<ListNode<String>>[]'), converters[3])
+
+    def test_array_nested_array_nested_linked_list(self):
+        tree = SyntaxTree.of(['array(array(linked_list(string))'])
+        arg_converters, converters = self.converter.get_converters(tree)
+        self.assertEqual(1, len(arg_converters))
+        self.assertEqual(4, len(converters))
+        self.assertEqual(ConverterFn('', '''return value.asText();''', 'JsonNode', 'String'), converters[0])
+        self.assertEqual(ConverterFn('', '''
+            ListNode<String>[] result[] = new ListNode[value.size()][];
+            int i = 0;
+            for (JsonNode node : value) {
+                result[i++] = converter3(node);
+            }
+            return result; 
+        ''', 'JsonNode', 'ListNode<String>[][]'), converters[3])

--- a/pylib/testing/framework/tests/test_js_input_converter.py
+++ b/pylib/testing/framework/tests/test_js_input_converter.py
@@ -89,6 +89,9 @@ class JsInputConverterTests(unittest.TestCase):
         self.assertEqual(2, len(converters))
         self.assertEqual(ConverterFn('', '''return value''', ''), converters[0])
         self.assertEqual(ConverterFn('', '''
+            if (!value) {
+                return null;
+            }
             const nodes = []
             for (let n of value) {
                 let node = new BinaryTreeNode()

--- a/pylib/testing/framework/tests/test_python_input_converter.py
+++ b/pylib/testing/framework/tests/test_python_input_converter.py
@@ -95,6 +95,8 @@ class PythonInputConverterTests(unittest.TestCase):
         self.assertEqual(2, len(converters))
         self.assertEqual(ConverterFn('', '\treturn str(value)', '', 'str'), converters[0])
         self.assertEqual(ConverterFn('', '''
+            if value is None:
+                return None
             nodes = []
             for item in value:
                 node = BinaryTreeNode()


### PR DESCRIPTION
- java generics cutting from type during the array creation (to avoid "generic array creation"